### PR TITLE
Add "rtid" commandline option

### DIFF
--- a/clioptions.cpp
+++ b/clioptions.cpp
@@ -51,6 +51,8 @@ CliOptions parseCliOptions(int argc, char** argv)
                                      {"relative-timestamps"});
     args::Flag skipInstantEventsArg(parser, "skip-instant-events", "don't emit instant events (ph: i)",
                                     {"skip-instant-events"});
+    args::Flag relativeTid(parser, "rtid", "subtract pid from tid so that main threads have tid = 0 (only works if vpid and vtid properties present in the context)",
+                                    {"rtid"});
     args::Positional<std::filesystem::path> pathArg(
         parser, "path", "The path to an LTTng trace folder, will be searched recursively for trace data");
     try {
@@ -82,5 +84,6 @@ CliOptions parseCliOptions(int argc, char** argv)
         args::get(printStatsArg),
         args::get(relativeTimestampsArg),
         args::get(skipInstantEventsArg),
+        args::get(relativeTid),
     };
 }

--- a/clioptions.h
+++ b/clioptions.h
@@ -43,6 +43,7 @@ struct CliOptions
     bool enableStatistics = false;
     bool relativeTimestamps = false;
     bool skipInstantEvents = false;
+    bool relativeTid = false;
 };
 
 CliOptions parseCliOptions(int argc, char** argv);

--- a/ctf2ctf.cpp
+++ b/ctf2ctf.cpp
@@ -1350,6 +1350,9 @@ struct Event
                 context->setTid(cpuId, tid);
                 context->setPid(tid, pid);
             }
+            if (context->options.relativeTid) {
+                tid -= pid;
+            }
         }
 
         if (!event_fields_scope) {


### PR DESCRIPTION
Add option to subtract vtid from vpi so that main thread has id=0 in the traces